### PR TITLE
various improvements to support for Rocoto, SLURM, and multi-document YAML from CROW-HAFS project

### DIFF
--- a/crow/config/__init__.py
+++ b/crow/config/__init__.py
@@ -24,7 +24,8 @@ __all__=["from_string","from_file", 'Action', 'Platform', 'Template',
          'Taskable', 'Task', 'Family', 'CycleAt', 'CycleTime', 'Cycle',
          'Trigger', 'Depend', 'Timespec', 'SuitePath', 'ShellEvent', 'Event',
          'DataEvent', 'CycleExistsDependency', 'validate', 'EventDependency',
-         'TaskExistsDependency', 'follow_main', 'from_dir', 'update_globals' ]
+         'TaskExistsDependency', 'follow_main', 'from_dir', 'update_globals',
+         'apply_inherit' ]
 
 _logger=logging.getLogger('crow.config')
 
@@ -69,6 +70,22 @@ def _recursive_validate(obj,stage,memo=None):
         obj._validate(stage)
         for k,v in obj.items():
             _recursive_validate(v,stage,memo)
+
+def _recursive_inherit(obj,stage,memo=None):
+    if memo is None: memo=set()
+    if id(obj) in memo: return
+    memo.add(id(obj))
+    if hasattr(obj,'_do_not_validate'): return
+    if hasattr(obj,'_inherit'):
+        obj._inherit(stage)
+        for k,v in obj.items():
+            _recursive_inherit(v,stage,memo)
+
+def apply_inherit(obj,stage='',recurse=False):
+    if recurse:
+        _recursive_inherit(obj,stage)
+    elif hasattr(obj,'_inherit'):
+        obj._validate(inherit,set())
 
 def validate(obj,stage='',recurse=False):
     if recurse:

--- a/crow/config/__init__.py
+++ b/crow/config/__init__.py
@@ -37,14 +37,19 @@ def expand_text(text,scope):
 
 evaluate_immediates=_evaluate_immediates
 
-def from_string(s,evaluate_immediates=True,validation_stage=None):
+def from_string(s,evaluate_immediates=True,validation_stage=None,multi_document=False):
     if not s: raise TypeError('Cannot parse null string')
-    c=ConvertFromYAML(yaml.load(s, Loader=yaml.Loader),CONFIG_TOOLS,ENV)
+    if multi_document:
+        loaded = [ y for y in yaml.load_all(s, Loader=yaml.Loader) ]
+    else:
+        loaded = yaml.load(s, Loader=yaml.Loader)
+    c=ConvertFromYAML(loaded,CONFIG_TOOLS,ENV)
     result=c.convert(validation_stage=validation_stage,
-                     evaluate_immediates=evaluate_immediates)
+                     evaluate_immediates=evaluate_immediates,
+                     multi_document=multi_document)
     return result
 
-def from_file(*args,evaluate_immediates=True,validation_stage=None):
+def from_file(*args,evaluate_immediates=True,validation_stage=None,multi_document=False):
     if not args: raise TypeError('Specify which files to read.')
     data=list()
     for file in args:
@@ -52,7 +57,8 @@ def from_file(*args,evaluate_immediates=True,validation_stage=None):
             data.append(fopen.read())
     return from_string(u'\n\n\n'.join(data),
                        evaluate_immediates=evaluate_immediates,
-                       validation_stage=validation_stage)
+                       validation_stage=validation_stage,
+                       multi_document=multi_document)
 
 def _recursive_validate(obj,stage,memo=None):
     if memo is None: memo=set()

--- a/crow/config/eval_tools.py
+++ b/crow/config/eval_tools.py
@@ -304,7 +304,7 @@ class dict_eval(MutableMapping):
     def __iter__(self):
         for k in self.__child.keys(): yield k
     def _inherit(self,stage,memo=None):
-
+        """!If requested, inherit contents of other scopes into this scope."""
         # Make sure we don't get infinite recursion:
         if memo is None: memo=set()
         if id(self) in memo:
@@ -322,8 +322,10 @@ class dict_eval(MutableMapping):
                 _logger.warning(f'{self._path}: Inherit is not an !Inherit.  Error?')
         elif superdebug:
             _logger.debug(f'{self._path}: no Inherit')
+
     def _validate(self,stage,memo=None):
         """!Validates this dict_eval using its embedded Template object, if present """
+        if memo is None: memo=set()
         if self.__is_validated: return
         self.__is_validated=True
 

--- a/crow/config/from_yaml.py
+++ b/crow/config/from_yaml.py
@@ -40,6 +40,7 @@ class FirstMinYAML(list):         yaml_tag=u'!FirstMin'
 class FirstTrueYAML(list):        yaml_tag=u'!FirstTrue'
 class LastTrueYAML(list):         yaml_tag=u'!LastTrue'
 class ImmediateYAML(list):        yaml_tag=u'!Immediate'
+class UncachedYAML(list):         yaml_tag=u'!Uncached'
 class InheritYAML(list):          yaml_tag=u'!Inherit'
 class MergeMappingYAML(list):     yaml_tag=u'!MergeMapping'
 class AppendSequenceYAML(list):     yaml_tag=u'!AppendSequence'
@@ -124,9 +125,14 @@ def add_yaml_string(key,cls):
     yaml.add_constructor(key,constructor)
 
 add_yaml_string(u'!expand',expand)
+add_yaml_string(u'!iexpand',iexpand)
+add_yaml_string(u'!uexpand',uexpand)
 add_yaml_string(u'!calc',calc)
 add_yaml_string(u'!icalc',icalc)
+add_yaml_string(u'!ucalc',ucalc)
 add_yaml_string(u'!ref',ref)
+add_yaml_string(u'!iref',iref)
+add_yaml_string(u'!uref',uref)
 add_yaml_string(u'!error',user_error_message)
 add_yaml_string(u'!Depend',Depend)
 add_yaml_string(u'!Message',Message)
@@ -164,6 +170,7 @@ add_yaml_sequence(u'!FirstMin',FirstMinYAML)
 add_yaml_sequence(u'!LastTrue',LastTrueYAML)
 add_yaml_sequence(u'!FirstTrue',FirstTrueYAML)
 add_yaml_sequence(u'!Immediate',ImmediateYAML)
+add_yaml_sequence(u'!Uncached',UncachedYAML)
 add_yaml_sequence(u'!Inherit',InheritYAML)
 add_yaml_sequence(u'!AppendSequence',AppendSequenceYAML)
 add_yaml_sequence(u'!MergeMapping',MergeMappingYAML)
@@ -251,8 +258,11 @@ class ConvertFromYAML(object):
         self.immediates=dict()
         self.ENV=ENV
 
-    def convert(self,validation_stage,evaluate_immediates):
-        self.result=self.from_dict(self.tree,path='doc')
+    def convert(self,validation_stage,evaluate_immediates,multi_document):
+        if multi_document:
+            self.result=self.from_list(self.tree,path='doc',locals={})
+        else:
+            self.result=self.from_dict(self.tree,path='doc')
         globals={ 'tools':self.tools, 'doc':self.result, 'ENV': self.ENV }
         self.result._recursively_set_globals(globals)
         if evaluate_immediates:
@@ -287,6 +297,8 @@ class ConvertFromYAML(object):
             return self.from_dict(v,SUITE[cls],path)
         elif cls is ImmediateYAML:
             return self.from_list(v,locals,Immediate,path)
+        elif cls is UncachedYAML:
+            return self.from_list(v,locals,Uncached,path)
         elif cls is InheritYAML:
             return self.from_list(v,locals,Inherit,path)
         elif cls is MergeMappingYAML:

--- a/crow/config/represent.py
+++ b/crow/config/represent.py
@@ -6,7 +6,7 @@ import re, abc, logging, sys, collections
 from datetime import timedelta
 from copy import deepcopy
 from crow.config.exceptions import *
-from crow.config.eval_tools import list_eval, dict_eval, multidict, from_config, strcalc, strref, stricalc
+from crow.config.eval_tools import list_eval, dict_eval, multidict, from_config, strcalc, strref, stricalc, stricalc, strucalc, striref, struref
 from crow.tools import to_timedelta, Clock
 from copy import copy
 import crow.sysenv
@@ -17,8 +17,9 @@ _logger=logging.getLogger('crow.config')
 __all__=[ 'Action','Platform', 'Conditional', 'ref','calc','FirstMin',
           'FirstMax', 'LastTrue', 'FirstTrue', 'GenericList',
           'GenericDict', 'GenericOrderedDict', 'ShellCommand',
-          'Immediate', 'ClockMaker', 'JobResourceSpecMaker',
-          'MergeMapping', 'AppendSequence', 'Select', 'icalc' ]
+          'Immediate', 'ClockMaker', 'JobResourceSpecMaker', 'Uncached',
+          'MergeMapping', 'AppendSequence', 'Select', 'icalc', 'ucalc',
+          'iref', 'uref' ]
 
 ########################################################################
 
@@ -108,6 +109,11 @@ class Immediate(list_eval):
     def _result(self,globals,locals):
         return self[0]
     def _is_immediate(self): pass
+
+class Uncached(list_eval): 
+    def _result(self,globals,locals):
+        return self[0]
+    def _do_not_cache(self): pass
 
 class Conditional(list_eval):
     MISSING=object()
@@ -213,4 +219,7 @@ class FirstTrue(Conditional):
 
 class calc(strcalc): pass
 class icalc(stricalc): pass
+class ucalc(strucalc): pass
 class ref(strref): pass
+class iref(striref): pass
+class uref(struref): pass

--- a/crow/config/tasks.py
+++ b/crow/config/tasks.py
@@ -147,6 +147,18 @@ class SuiteView(Mapping):
         self.parent=parent
         self.__cache={}
         assert(isinstance(self.viewed,Cycle) or 'this' in self.viewed)
+
+        if hasattr(self.viewed,'_inherit') and 'Validate' in self.viewed:
+            how=self.viewed.Validate
+            if how is False:
+                pass # do not validate
+            elif how=='validate':
+                self.viewed._validate('suite')
+            elif how=='inherit':
+                self.viewed._inherit('suite')
+            else:
+                raise ValueError(f'In !Inherit, "Validate" option value must be "inherit" or "validate" or False, not {how!r}')
+
         if isinstance(self.viewed,Slot):
             locals=multidict(self.parent,self.viewed)
             globals=self.viewed._get_globals()

--- a/crow/config/tasks.py
+++ b/crow/config/tasks.py
@@ -348,6 +348,10 @@ class SuiteView(Mapping):
         dep=as_dependency(other)
         if dep is NotImplemented: return dep
         return OrDependency(as_dependency(self),dep)
+    def __rand__(self,other):
+        return self.__and__(other)
+    def __ror__(self,other):
+        return self.__or__(other)
     def __invert__(self):
         return NotDependency(StateDependency(self,COMPLETED))
     def is_running(self):
@@ -607,6 +611,8 @@ def as_dependency(obj,path=MISSING,state=COMPLETED):
 class LogicalDependency(object):
     def __invert__(self):          return NotDependency(self)
     def __contains__(self,dep):    return False
+    def __rand__(self,other):      return self.__and__(other)
+    def __ror__(self,other):       return self.__or__(other)
     def __and__(self,other):
         if other is FALSE_DEPENDENCY: return other
         if other is TRUE_DEPENDENCY: return self

--- a/crow/config/to_yaml.py
+++ b/crow/config/to_yaml.py
@@ -3,7 +3,7 @@ import sys, logging
 from yaml.nodes import MappingNode, ScalarNode, SequenceNode
 from copy import copy
 from collections import OrderedDict
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from crow.tools import Clock
 from crow.config.eval_tools import *
 from crow.config.represent import *
@@ -24,7 +24,10 @@ _logger=logging.getLogger('crow.config')
 def to_yaml(yml):
     if hasattr(yml,'_raw_cache'):
         yml=copy(yml._raw_child())
-    return yaml.dump(yml)
+    if isinstance(yml,Sequence):
+        return yaml.dump_all(yml)
+    else:
+        return yaml.dump(yml)
 
 ########################################################################
 
@@ -41,6 +44,7 @@ add_yaml_list_eval(u'!FirstMin',FirstMin)
 add_yaml_list_eval(u'!LastTrue',LastTrue)
 add_yaml_list_eval(u'!FirstTrue',FirstTrue)
 add_yaml_list_eval(u'!Immediate',Immediate)
+add_yaml_list_eval(u'!Uncached',Uncached)
 add_yaml_list_eval(u'!JobRequest',JobResourceSpecMaker)
 add_yaml_list_eval(u'!Inherit',Inherit)
 add_yaml_list_eval(u'!MergeMapping',MergeMapping)

--- a/crow/metascheduler/dummy.py
+++ b/crow/metascheduler/dummy.py
@@ -9,9 +9,9 @@ class ToDummy(object):
         if apply_overrides:
             self.suite.apply_overrides()
 
-    def defenvar(self,name,value): return 'dummy'
+    def defenvar(self,name,value,literal=False): return 'dummy'
     def datestring(self,name,value): return 'dummy'
-    def defvar(self,name,value): return 'dummy'
+    def defvar(self,name,value,literal=False): return 'dummy'
     def varref(self,name): return 'dummy'
     def to_dummy(self): return 'dummy'
 

--- a/crow/metascheduler/ecflow.py
+++ b/crow/metascheduler/ecflow.py
@@ -157,10 +157,10 @@ class ToEcflow(object):
             return( (m.group(1) or "")+"%"+m.group(2)+"%" )
         return re.sub(r'(\%\%)*\%([a-zA-Z])',replacer,format)
 
-    def defenvar(self,name,value):
+    def defenvar(self,name,value,literal=False):
         return f"edit {name} '{value!s}'"
 
-    def defvar(self,name,value):
+    def defvar(self,name,value,literal=False):
         return f"edit {name} '{value!s}'"
 
     def varref(self,name):

--- a/crow/sysenv/jobs.py
+++ b/crow/sysenv/jobs.py
@@ -19,7 +19,7 @@ MAXIMUM_THREADS=sys.maxsize
 
 class JobRankSpec(Mapping):
     OPTIONAL_ATTRIBUTES=[
-        'walltime', 'memory', 'outer', 'stdout', 'stderr', 'jobname',
+        'walltime', 'memory', 'outerr', 'stdout', 'stderr', 'jobname',
         'batch_memory', 'compute_memory', 'lsf_affinity' ]
 
     def __init__(self,OMP_NUM_THREADS=0,mpi_ranks=0,

--- a/crow/sysenv/schedulers/Slurm.py
+++ b/crow/sysenv/schedulers/Slurm.py
@@ -136,13 +136,11 @@ class Scheduler(BaseScheduler):
         if 'queue' in spec:
             sio.write(f'{indent*space}<queue>{"batch"}</queue>\n')
         if 'partition' in spec:
-            sio.write(f'{indent*space}<partition>{spec["partition"]!s}</partition>\n')
+            sio.write(f'{indent*space}<native>--partition={spec["partition"]!s}</native>\n')
         if 'account' in spec:
             sio.write(f'{indent*space}<account>{spec["account"]!s}</account>\n')
-        if 'project' in spec:
+        elif 'project' in spec:
             sio.write(f'{indent*space}<account>{spec["project"]!s}</account>\n')
-        if 'account' in spec:
-            sio.write(f'{indent*space}<account>{spec["account"]!s}</account>\n')
         if 'jobname' in spec:
             sio.write(f'{indent*space}<jobname>{spec["jobname"]!s}</jobname>\n')
         if 'reservation' in spec:

--- a/crow/sysenv/schedulers/Slurm.py
+++ b/crow/sysenv/schedulers/Slurm.py
@@ -18,7 +18,7 @@ class Scheduler(BaseScheduler):
         self.settings=dict(settings)
         self.settings.update(kwargs)
         self.nodes=GenericNodeSpec(settings)
-        self.rocoto_name='Slurm'
+        self.rocoto_name='slurm'
         self.indent_text=str(settings.get('indent_text','  '))
 
     def max_ranks_per_node(self,spec):

--- a/crow/sysenv/schedulers/Slurm.py
+++ b/crow/sysenv/schedulers/Slurm.py
@@ -134,7 +134,7 @@ class Scheduler(BaseScheduler):
         space=self.indent_text
         sio=StringIO()
         if 'queue' in spec:
-            sio.write(f'{indent*space}<queue>{"batch"}</queue>\n')
+            sio.write(f'{indent*space}<queue>{spec["queue"]}</queue>\n')
         if 'partition' in spec:
             sio.write(f'{indent*space}<native>--partition={spec["partition"]!s}</native>\n')
         if 'account' in spec:


### PR DESCRIPTION
Overview:

1. A multitude of bug fixes to SLURM support
2. `!Inherit` now accepts options.  A "should I recurse?" option is added.
3. Corrections to syntax errors of XML generated by `crow.metascheduler.rocoto`
4. Ability to not quote XML special characters when defining entities via `crow.metascheduler.rocoto`
5. You can tell CROW not to cache the results of calculations using `!ucalc`, `!uref`, `!uexpand`, and `!Uncached`
6. Added `!iref` and `!iexpand` which correspond to the reference and string expansion versions of the existing `!icalc`
7. The ability to read multi-document YAML files.  This is enabled by a flag set when reading, and will provide a list of dicts instead of a dict.  If you don't set the flag, the old behavior will prevail.

Commit messages contain further details.